### PR TITLE
Quick reply object

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ def main(sender_id, cmd, **extends):
             "payload": Payload('/membre', name='Rivo')
         }
     ]
-    ##### FOR v1.0.5+ 
+    
     '''
+    ##### FOR v1.0.5+ #########
     from ampalibe import QuickReply
     quick_rep = [
         QuickReply(title='Angela', payload=Payload('/membre', name='Angela', ref='2016-sac')),

--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ def main(sender_id, cmd, **extends):
             "payload": Payload('/membre', name='Rivo')
         }
     ]
+    ##### FOR v1.0.5+ 
+    '''
+    from ampalibe import QuickReply
+    quick_rep = [
+        QuickReply(title='Angela', payload=Payload('/membre', name='Angela', ref='2016-sac')),
+        QuickReply(title='Rivo', payload=Payload('/membre', name='Rivo'))
+    ]   
+    '''
     chat.send_quick_reply(sender_id, quick_rep, 'Who?')
     
 

--- a/ampalibe/__init__.py
+++ b/ampalibe/__init__.py
@@ -1,5 +1,5 @@
 from .requete import Model
-from .messenger import Messenger
+from .messenger import Messenger, QuickReply
 from .core import webserver, Extra as init
 from .utils import action, command, download_file, Payload
 

--- a/ampalibe/messenger.py
+++ b/ampalibe/messenger.py
@@ -8,6 +8,43 @@ from retry import retry
 from .utils import Payload
 
 
+class QuickReply:
+
+    def __init__(self, **kwargs):
+        '''
+            Object that can be used to generated a quick_reply
+        '''
+        self.content_type = kwargs.get('content_type', 'text')
+        if self.content_type not in ('text', 'user_phone_number', 'user_email'):
+            raise ValueError("content_type can only be 'text', 'user_phone_number', 'user_email'")
+
+        self.title = kwargs.get('title')
+        self.payload = kwargs.get('payload')
+
+        if self.content_type == 'text' and not self.payload:
+            raise ValueError("payload must be present for text")
+
+        if self.content_type == 'text' and not self.title:
+            raise ValueError("title must be present for text")
+
+        self.image_url = kwargs.get('content_type', 'text')
+
+    @property
+    def value(self):
+        res = {'content_type': self.content_type}
+
+        if self.content_type == 'text':
+            res['title'] = self.title
+            res['payload'] = self.payload
+
+            if self.image_url:
+                res['image_url'] = self.image_url 
+        return res
+
+    def __str__(self):
+        return str(self.value)
+
+
 
 class Messenger:
     def __init__(self, access_token, log_level='error'):
@@ -146,6 +183,8 @@ class Messenger:
         """
 
         for i in range(len(quick_rep[:12])):
+            if isinstance(quick_rep[i], QuickReply):
+                quick_rep[i] = quick_rep[i].value
             if quick_rep[i].get('payload'):
                 quick_rep[i]['payload'] = Payload.trt_payload_out(quick_rep[i]['payload'])
 

--- a/ampalibe/messenger.py
+++ b/ampalibe/messenger.py
@@ -27,7 +27,7 @@ class QuickReply:
         if self.content_type == 'text' and not self.title:
             raise ValueError("title must be present for text")
 
-        self.image_url = kwargs.get('content_type')
+        self.image_url = kwargs.get('image_url')
 
     @property
     def value(self):

--- a/ampalibe/messenger.py
+++ b/ampalibe/messenger.py
@@ -27,7 +27,7 @@ class QuickReply:
         if self.content_type == 'text' and not self.title:
             raise ValueError("title must be present for text")
 
-        self.image_url = kwargs.get('content_type', 'text')
+        self.image_url = kwargs.get('content_type')
 
     @property
     def value(self):

--- a/docs/source/messenger.rst
+++ b/docs/source/messenger.rst
@@ -98,6 +98,28 @@ to request a person's location, email address, and phone number.
 
     chat.send_quick_reply(sender_id, quick_rep, 'who do you choose ?')
 
+OR 
+
+.. code-block:: python
+    
+    from ampalibe import QuickReply
+    ... 
+
+    quick_rep = [
+        QuickReply(
+            title="Angela",
+            payload="/membre",
+            image_url="https://i.imgflip.com/6b45bi.jpg"
+        ),
+        QuickReply(
+            title="Rivo",
+            payload="/membre",
+            image_url="https://i.imgflip.com/6b45bi.jpg"
+        ),
+    ]
+
+    chat.send_quick_reply(sender_id, quick_rep, 'who do you choose ?')
+
 
 send_template
 _____________


### PR DESCRIPTION
Pour utiliser entièrement du Python,Je propose aussi la possibilité d'utiliser des objets pour les types dictionnaires, je commence par les quick_reply

```python 
import ampalibe
from ampalibe import Payload
# Remarqué que j'importe ici
from ampalibe import QuickReply
from conf import Configuration

bot = ampalibe.init(Configuration())
chat = bot.chat

@ampalibe.command('/')
def main(sender_id, cmd, **extends):
    list_items = [
        QuickReply(title="Aiza e", payload=Payload('/item', id_item=5)),
        QuickReply(content_type='user_email')
    ]

    chat.send_quick_reply(sender_id, list_items, 'ino o ?')

@ampalibe.command('/item')
def get_item(sender_id, id_item, **extends):
    chat.send_message(sender_id, f"item n°{id_item} selected")
```

> N.B: les dictionnaires sont toujours disponibles