### PR TITLE
[IMP] Preserve the built-in type of data sent on Payload Management

### DIFF
--- a/ampalibe/utils.py
+++ b/ampalibe/utils.py
@@ -87,7 +87,10 @@ class Payload:
                 # object to string
                 val_data = codecs.encode(pickle.dumps(val_data), "base64").decode()
                 tmp += f"{{{{{key_data}==={val_data}}}}} "
-            return urllib.parse.quote(payload.payload + " " + tmp)
+            final_pl = payload.payload + " " + tmp
+            if len(final_pl)>=2000:
+                raise Exception("Payload data is too large")
+            return urllib.parse.quote(final_pl)
         return urllib.parse.quote(payload)
 
 

--- a/ampalibe/utils.py
+++ b/ampalibe/utils.py
@@ -66,7 +66,8 @@ class Payload:
             start = payload.index("{{")
             end = payload.index("}}")
             items = payload[start + 2 : end].split("===")
-            res[items[0]] = items[1]
+            # result string to object
+            res[items[0]] = pickle.loads(codecs.decode(items[1].encode(), "base64"))
             payload = payload.replace(payload[start : end + 2], "").strip()
         return payload0.copy(payload) if isinstance(payload0, Cmd) else payload, res
 
@@ -81,6 +82,8 @@ class Payload:
         if isinstance(payload, Payload):
             tmp = ""
             for key_data, val_data in payload.data.items():
+                # object to string
+                val_data = codecs.encode(pickle.dumps(val_data), "base64").decode()
                 tmp += f"{{{{{key_data}==={val_data}}}}} "
             return urllib.parse.quote(payload.payload + " " + tmp)
         return urllib.parse.quote(payload)

--- a/ampalibe/utils.py
+++ b/ampalibe/utils.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import json
+import codecs
+import pickle
 import requests
 import urllib.parse
 from conf import Configuration  # type: ignore


### PR DESCRIPTION
When you set a type built-in in Payload argument,
the result is type built-in in result and not str
![image](https://user-images.githubusercontent.com/43904633/186678976-40d90c3c-c2d6-477c-af73-a7ae1606dc2a.png)

____________________________________

![image](https://user-images.githubusercontent.com/43904633/186684876-2ed73beb-5841-4fea-bf38-afa05bcc517b.png)


