### PR TITLE
[FEAT] Object Payload sent in action

### DIFF
--- a/ampalibe/core.py
+++ b/ampalibe/core.py
@@ -107,6 +107,9 @@ class Server:
             os.remove(f"assets/private/.__{sender_id}")
 
         payload, kw = Payload.trt_payload_in(payload)
+        if action:
+            action, kw_tmp = Payload.trt_payload_in(action)
+            kw.update(kw_tmp)
         command = funcs["command"].get(payload.split()[0])
         kw["sender_id"] = sender_id
         kw["cmd"] = payload

--- a/ampalibe/messenger.py
+++ b/ampalibe/messenger.py
@@ -38,8 +38,10 @@ class Messenger:
 
     @property
     def token(self):
-        if self.access_token.strip() == "":
-            print("Warning! EMPTY PAGE ACCESS TOKEN", file=stderr)
+        if not self.access_token:
+            print(
+                "\033[48:5:166m⚠ Warning!\033[0m EMPTY PAGE ACCESS TOKEN", file=stderr
+            )
         return self.access_token
 
     @retry(requests.exceptions.ConnectionError, tries=3, delay=3)

--- a/ampalibe/model.py
+++ b/ampalibe/model.py
@@ -1,4 +1,5 @@
 import json
+from .utils import Payload
 from conf import Configuration  # type: ignore
 
 
@@ -59,7 +60,7 @@ class Model:
                 CREATE TABLE IF NOT EXISTS `amp_user` (
                     `id` INT NOT NULL AUTO_INCREMENT,
                     `user_id` varchar(50) NOT NULL UNIQUE,
-                    `action` varchar(50) DEFAULT NULL,
+                    `action` TEXT DEFAULT NULL,
                     `last_use` datetime NOT NULL DEFAULT current_timestamp(),
                     `lang` varchar(5) DEFAULT NULL,
                     `tmp` varchar(255) DEFAULT NULL,
@@ -71,7 +72,7 @@ class Model:
                 CREATE TABLE IF NOT EXISTS  "amp_user" (
                     id SERIAL,
                     user_id VARCHAR NULL DEFAULT NULL,
-                    action VARCHAR NULL DEFAULT NULL,
+                    action TEXT NULL DEFAULT NULL,
                     tmp VARCHAR NULL DEFAULT NULL,
                     last_use TIMESTAMP NULL DEFAULT NOW(),
                     lang VARCHAR NULL DEFAULT NULL,
@@ -167,9 +168,12 @@ class Model:
         """
         define a current action if an user
 
-        @params :  user_id
+        @params :  user_id, action
         @return:  None
         """
+        if isinstance(action, Payload):
+            action = Payload.trt_payload_out(action)
+
         if self.ADAPTER == "MYSQL" or self.ADAPTER == "POSTGRESQL":
             req = "UPDATE amp_user set action = %s WHERE user_id = %s"
         else:

--- a/automate/app/core.py
+++ b/automate/app/core.py
@@ -38,3 +38,16 @@ def action_work(sender_id, cmd, **extends):
     if query.get_temp(sender_id, "myname") != myname:
         return cmd + " " + myname
     return "Del temp error"
+
+
+@ampalibe.command("/try_second_action")
+def try_second_action(sender_id, **extends):
+    query.set_action(
+        sender_id, Payload("/second_action_work", myname="Ampalibe", version=2)
+    )
+
+
+@ampalibe.action("/second_action_work")
+def second_action_work(sender_id, cmd, myname, version, **extends):
+    query.set_action(sender_id, None)
+    return cmd + " " + myname + str(version)

--- a/automate/test.sh
+++ b/automate/test.sh
@@ -26,5 +26,16 @@ else
     exit 1
 fi
 
+####### ACTION TEST && Payload data TEST #######
+simulate '"/try_second_action"' > /dev/null
+res=$(simulate '"Hello"')
+if [ "$res" = '"Hello Ampalibe2"' ]; then
+    echo "Message: OK Second Action"
+    echo "Message: OK Payload data in action"
+else
+    echo KO
+    exit 1
+fi
+
 
 


### PR DESCRIPTION
- set_action can receive Payload Object
- action decorator can receive data send in payload object
- Unit test for Payload in action added

### Example 
```python
@ampalibe.command("/try_second_action")
def try_second_action(sender_id, **extends):
    query.set_action(
        sender_id, Payload("/second_action_work", myname="Ampalibe", version=2)
    )


@ampalibe.action("/second_action_work")
def second_action_work(sender_id, cmd, myname, version, **extends):
    query.set_action(sender_id, None)
    return cmd + " " + myname + str(version)

``` 


### TEST 

```bash 
function simulate {
    echo $(curl -H "Content-Type: application/json" -X POST "http://127.0.0.1:4555/?testmode=1" -d "{\"object\": \"page\", \"entry\": [{\"messaging\": [ {\"sender\": {\"id\": \"test_user\"}, \"message\": {\"text\":$1} }]}]}")
}

####### ACTION TEST && Payload data TEST #######
simulate '"/try_second_action"' > /dev/null
res=$(simulate '"Hello"')
if [ "$res" = '"Hello Ampalibe2"' ]; then
    echo "Message: OK Second Action"
    echo "Message: OK Payload data in action"
else
    echo KO
    exit 1
fi
```

