### PR TITLE
[ADD] new messenger api : send receipt template

### DIFF
--- a/ampalibe/messenger.py
+++ b/ampalibe/messenger.py
@@ -7,7 +7,9 @@ from retry import retry
 import requests_toolbelt
 from .utils import Payload
 from conf import Configuration  # type: ignore
-from .ui import QuickReply, Button, Element, ReceiptElement, Summary, Address, Adjustment  # type: ignore
+from .ui import Summary, Address, Adjustment
+from .ui import Button, QuickReply, Element, ReceiptElement
+
 
 
 class Action:

--- a/ampalibe/messenger.py
+++ b/ampalibe/messenger.py
@@ -7,7 +7,7 @@ from retry import retry
 import requests_toolbelt
 from .utils import Payload
 from conf import Configuration  # type: ignore
-from .ui import QuickReply, Button, Element
+from .ui import QuickReply, Button, Element, ReceiptElement, Summary, Address, Adjustment  # type: ignore
 
 
 class Action:
@@ -728,3 +728,71 @@ class Messenger:
         )
         res = self.__analyse(res)
         return res.json()
+
+    @retry(requests.exceptions.ConnectionError, tries=3, delay=3)
+    def send_receipt_template(
+            self, dest_id, recipient_name, order_number, payment_method, receipt_elements, summary, currency="MGA", address=None, adjustments=None, order_url=None, timestamp=None):
+        """
+        Method that sends a receipt template to a customer  .
+
+        Args:
+            recipient_name (str | required ): The name of the recipient
+            order_number (str | required ): The order number
+            payment_method (str | required ): The payment method
+            summary (Summary obj or dict | required ): The summary of the order
+            currency (str): The currency of the order
+            address (Adresse obj or dict | optional ): The address of the recipient
+            adjustments (list of Adjustment obj or dict | optional ): The adjustments of the order
+            order_url (str | optionnal ): The url of the order
+            timestamp (str | optionnal ): The timestamp of the order
+
+        Returns:
+            Response: POST request to the facebook API to send a receipt template
+
+        Ref:
+            https://developers.facebook.com/docs/messenger-platform/reference/templates/receipt
+        """
+
+        if receipt_elements:
+            receipt_elements = [
+                receipt.value if isinstance(receipt, ReceiptElement) else receipt
+                for receipt in receipt_elements
+            ]
+
+        summary = summary.value if isinstance(summary, Summary) else summary
+        address = address.value if isinstance(address, Address) else address
+
+        if adjustments:
+            adjustments = [
+                adjustment.value if isinstance(adjustment, Adjustment) else adjustment
+                for adjustment in adjustments
+            ]
+
+        dataJSON = {
+            "recipient": {"id": dest_id},
+            "message": {
+                "attachment": {
+                    "type": "template",
+                    "payload": {
+                        "template_type": "receipt",
+                        "recipient_name": recipient_name,
+                        "order_number": order_number,
+                        "currency": currency,
+                        "payment_method": payment_method,
+                        "address": address,
+                        "summary": summary,
+                        "elements": receipt_elements,
+                        "order_url": order_url,
+                        "adjustments": adjustments,
+                        "timestamp": timestamp
+                    },
+                }
+            },
+        }
+        header = {"content-type": "application/json; charset=utf-8"}
+        params = {"access_token": self.token}
+
+        res = requests.post(
+            self.url + "/messages", json=dataJSON, headers=header, params=params
+        )
+        return self.__analyse(res)

--- a/ampalibe/ui.py
+++ b/ampalibe/ui.py
@@ -154,3 +154,140 @@ class Element:
 
     def __str__(self):
         return str(self.value)
+
+
+class ReceiptElement:
+    def __init__(self, **kwargs):
+        self.title = kwargs.get("title")
+        self.subtitle = kwargs.get("subtitle")
+        self.quantity = kwargs.get("quantity")
+        self.price = kwargs.get("price")
+        self.currency = kwargs.get("currency")
+        self.image = kwargs.get("image_url")
+
+        if not self.title:
+            raise ValueError("Receipt element must be have a title")
+
+        if not self.price:
+            raise ValueError("Receipt element must be have a price")
+
+    @property
+    def value(self):
+        res = {"title": self.title}
+
+        if self.subtitle:
+            res["subtitle"] = self.subtitle
+
+        if self.quantity:
+            res["quantity"] = self.quantity
+
+        res["price"] = self.price
+        res["currency"] = self.currency
+
+        if self.image:
+            res["image_url"] = self.image
+
+        return res
+
+    def __str__(self):
+        return str(self.value)
+
+
+class Summary:
+    def __init__(self, **kwargs):
+        self.subtotal = kwargs.get("subtotal")
+        self.shipping_cost = kwargs.get("shipping_cost")
+        self.total_tax = kwargs.get("total_tax")
+        self.total_cost = kwargs.get("total_cost")
+
+        if not self.total_cost:
+            raise ValueError("Summary must have a total_cost")
+
+    @property
+    def value(self):
+        res = {"total_cost": self.total_cost}
+
+        if self.shipping_cost:
+            res["shipping_cost"] = self.shipping_cost
+
+        if self.total_tax:
+            res["total_tax"] = self.total_tax
+
+        if self.subtotal:
+            res["subtotal"] = self.subtotal
+
+        return res
+
+    def __str__(self):
+        return str(self.value)
+
+
+class Address:
+    def __init__(self, **kwargs):
+        self.street_1 = kwargs.get("street_1")
+        self.street_2 = kwargs.get("street_2")
+        self.city = kwargs.get("city")
+        self.postal_code = kwargs.get("postal_code")
+        self.state = kwargs.get("state")
+        self.country = kwargs.get("country")
+
+        if not self.street_1:
+            raise ValueError("Address must have a street_1")
+
+        if not self.city:
+            raise ValueError("Address must have a city")
+
+        if not self.postal_code:
+            raise ValueError("Address must have a postal_code")
+
+        if not self.state:
+            raise ValueError("Address must have a state")
+
+        if not self.country:
+            raise ValueError("Address must have a country")
+
+    @property
+    def value(self):
+        res = {}
+
+        if self.street_1:
+            res["street_1"] = self.street_1
+
+        if self.street_2:
+            res["street_2"] = self.street_2
+
+        if self.city:
+            res["city"] = self.city
+
+        if self.postal_code:
+            res["postal_code"] = self.postal_code
+
+        if self.state:
+            res["state"] = self.state
+
+        if self.country:
+            res["country"] = self.country
+
+        return res
+
+    def __str__(self):
+        return str(self.value)
+
+
+class Adjustment:
+    def __init__(self, **kwargs):
+        self.name = kwargs.get("name")
+        self.amount = kwargs.get("amount")
+
+        if not self.name:
+            raise ValueError("Adjustment must be have a name")
+
+        if not self.amount:
+            raise ValueError("Adjustment must be have a amount")
+
+    @property
+    def value(self):
+        return {"name": self.name, "amount": self.amount}
+
+    def __str__(self):
+        return str(self.value)

--- a/docs/source/messenger.rst
+++ b/docs/source/messenger.rst
@@ -391,3 +391,54 @@ refer to other api in this link https://developers.facebook.com/docs/messenger-p
         
         *endpoint (str)*: the endpoint if is not '/messages'
 
+
+send_receipt_template
+________________
+
+it sends a receipt template to a customer to confirm his order.
+
+**Ref**:  https://developers.facebook.com/docs/messenger-platform/send-messages/template/receipt
+
+**Args**:
+    *recipient_name (str)*: The name of the recipient
+
+    *order_number (str)*: The order number
+
+    *payment_method (str)*: The payment method
+
+    *summary (Summary or dict)*: The summary of the order
+
+    *currency (str)*: The currency of the order
+
+    *address (Adresse or dict)*: The address of the recipient (optional)
+
+    *adjustments (list)*: The adjustments of the order (optional)
+
+    *order_url (str)*: The url of the order (optional)
+
+    *timestamp (str)*: The timestamp of the order (optional)
+
+**Example**:
+
+.. code-block:: python
+
+    from ampalibe.ui import ReceiptElement, Address, Summary, Adjustment
+    ...
+
+    # create a receipt element
+    receipts = [
+        ReceiptElement(title='Tee-shirt', price=1000),
+        ReceiptElement(title='Pants', price=2000),
+    ]
+
+    # create a summary
+    summary = Summary(total_cost=300)
+
+    # create an address
+    address = Address(street_1='Street 1', city='City', state='State', postal_code='Postal Code', country='Country')
+
+    # create an adjustment
+    adjustment = Adjustment(name='Discount of 10%', amount=10)
+
+    chat.send_receipt_template(
+        sender_id, "Arleme", 123461346131, "MVOLA", summary=summary, receipt_elements=receipts, currency='MGA', address=address, adjustments=[adjustment])

--- a/tests/test_api_messenger.py
+++ b/tests/test_api_messenger.py
@@ -1,7 +1,7 @@
 from os import environ, makedirs, removedirs
 from ampalibe import Messenger, Payload
 from ampalibe.messenger import Action, Filetype
-from ampalibe.ui import Button, Element, QuickReply, Type
+from ampalibe.ui import Button, Element, QuickReply, Type, ReceiptElement, Summary, Adjustment, Address
 
 chat = Messenger()
 sender_id = environ.get("USER_ID")
@@ -105,6 +105,7 @@ def test_send_button():
         == 200
     )
 
+
 def test_persitent_menu():
     persistent_menu = [
         Button(type='postback', title='Menu', payload='/payload'),
@@ -115,3 +116,25 @@ def test_persitent_menu():
         chat.persistent_menu(sender_id, persistent_menu).status_code
         == 200
     )
+
+
+def test_send_receipt_template():
+    receipts = [
+        ReceiptElement(title='Tee-shirt', price=1000),
+        ReceiptElement(title='Pants', price=2000),
+    ]
+
+    # create a summary
+    summary = Summary(total_cost=300)
+
+    # create an address
+    address = Address(street_1='Street 1', city='City', state='State', postal_code='Postal Code', country='Country')
+
+    # create an adjustment
+    adjustment = Adjustment(name='Discount of 10%', amount=10)
+
+    assert (
+        chat.send_receipt_template(
+            sender_id, "Arleme", 123461346131, "MVOLA", summary=summary, receipt_elements=receipts, currency='MGA', address=address, adjustments=[adjustment]
+        ).status_code
+    ) == 200


### PR DESCRIPTION
New messenger api for sending receipt to customer.

```py
    from ampalibe.ui import ReceiptElement, Address, Summary, Adjustment

    receipts = [
        ReceiptElement(title='Receipt 1', price=100),
        ReceiptElement(title='Receipt 2', price=200),
    ]

    # create a summary
    summary = Summary(total_cost=300)

    # create an address
    address = Address(street_1='Street 1', city='City',
                      state='State', postal_code='Postal Code', country='Country')

    # create an adjustment
    adjustment = Adjustment(name='Fienambidy', amount=10)

    chat.send_receipt_template(
        sender_id, "Arleme", 123461346131, "MVOLA", summary=summary, receipt_elements=receipts, currency='MGA', address=address, adjustments=[adjustment])

```

![image](https://user-images.githubusercontent.com/60097202/198902477-ba5b87d5-317f-43dc-988c-35f2d3889ad6.png)


