### PR TITLE
[IMP]] Make Sqlite support type datetime

### DIFF
--- a/ampalibe/model.py
+++ b/ampalibe/model.py
@@ -45,7 +45,10 @@ class Model:
         else:
             import sqlite3
 
-            self.db = sqlite3.connect(self.DB_CONF)
+            self.db = sqlite3.connect(
+                self.DB_CONF, 
+                detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
+            )
 
         self.cursor = self.db.cursor()
 


### PR DESCRIPTION
SQLite doesn't support datetime type, 
so when you get the value of last_use in sqlite, it returns a datetime with string format and datetime objetct, 

To solve this problem, use detect_types as PARSE_DECLTYPES and PARSE_COLNAMES as arguments in the connect method of the sqlite3 module.


**sqlite3.PARSE_DECLTYPES**

If you use this parameter in the connect method, then the sqlite3 module parses the declared type for each column it returns.

It will parse the declared type then use the type converters dictionary to execute the converter function registered for that type there.

**sqlite3.PARSE_COLNAMES**

If you use this parameter in the connect method, then the SQLite interface parses the column name for each column it returns. It will use the converters dictionary and then use the converter function found there to return the value.