### PR TITLE
bump to 1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,3 +170,27 @@
 * [IMP] Readability and maintainability (#74) 
 
 
+## Ampalibe 1.1.8
+
+* [ADD] Mongodb support (#76)
+* [IMP] Code quality (#87) (6a695791ab1b07f18cde89484ec41f72a8ed90c4)
+* [IMP] Optimize time for translate function (#77)
+* [IMP] Change temporary data management (#78) 
+* [FIX] translate encoding in windows (af9e1fba065a726243b8c518157f101cd7c2de4b)
+* [ADD] New Messenger API: send_product_template (#79)
+* [FIX] --dev doesn't work anymore on windows (af7aba3fb1f860109a3aa417de7bbda880f09ffb)
+* [ADD] One time notification Messenger API (#80)
+* [IMP] fix & imrpov structure (#81)
+* [IMP] Improve core readability (#82) (#83) 
+* [FIX] Logger , printing twice (#86)
+* [IMP] Model optimisation (#88)
+* [IMP] Minor syntax style (#89) 
+
+
+ 
+
+
+
+
+
+

--- a/ampalibe/__init__.py
+++ b/ampalibe/__init__.py
@@ -6,7 +6,7 @@ import colorama
 import tempfile
 from . import source
 
-__version__ = "1.2.0.dev"
+__version__ = "1.1.8"
 __author__ = "iTeam-$"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Ampalibe
-version = 1.2.0.dev
+version = 1.1.8
 author = iTeam-$
 author_email = contact@iteam-s.mg
 description = Ampalibe is a lightweight Python framework for building Facebook Messenger bots faster.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ampalibe",  # This is the name of the package
-    version="1.2.0.dev",  # The release version
+    version="1.1.8",  # The release version
     author="iTeam-$",  # Full name of the author
     description=(
         "Ampalibe is a lightweight Python framework for building Facebook"


### PR DESCRIPTION
Because the major_develop branch has development and major change, 

producing a release for the old structure is more sensible to have a stable version